### PR TITLE
Try to fix strange crash when init(layer) called during animation

### DIFF
--- a/Shimmer/ShimmeringLayer.swift
+++ b/Shimmer/ShimmeringLayer.swift
@@ -276,6 +276,9 @@ final public class ShimmeringLayer: CALayer {
         super.init(coder: aDecoder)
     }
 
+    override public init(layer: Any) {
+        super.init(layer: layer)
+    }
 }
 
 extension ShimmeringLayer: CALayerDelegate {

--- a/Shimmer/ShimmeringMaskLayer.swift
+++ b/Shimmer/ShimmeringMaskLayer.swift
@@ -47,6 +47,14 @@ final class ShimmeringMaskLayer: CAGradientLayer {
         super.init(coder: aDecoder)
     }
 
+    override init(layer: Any) {
+
+        if let layer = layer as? ShimmeringMaskLayer {
+            layer.fadeLayer.backgroundColor = UIColor.white.cgColor
+        }
+
+        super.init(layer: layer)
+    }
     override func layoutSublayers() {
         super.layoutSublayers()
         let rect = bounds


### PR DESCRIPTION
After this adjustment, we test it for a release version (thousands of sessions) and the crash disappear. 
https://github.com/BeauNouvelle/ShimmerSwift/issues/1
So take a look, we will be glad to merge this fix, because now we are using the pod from another repo.
